### PR TITLE
IsaacDealFixedNegativeValues

### DIFF
--- a/CSCD480something/MusicAlgorithmBinder/8. Source Code/js/welcome.js
+++ b/CSCD480something/MusicAlgorithmBinder/8. Source Code/js/welcome.js
@@ -75,7 +75,6 @@ function getNoteCount(textArea){
 function getTextAreaData(textArea){
 
 	var value = textArea.val();
-	value = value.replace(/-/g,''); // strips negative signs
 	value = value.replace(/,,/g,'');
 	value = value.split(",").map(Number);
 	var newData = new Array();
@@ -94,7 +93,6 @@ function getDataArray(textArea){
 	var $noteCount = $("#note_count"+getVoiceNumber(textArea));
 	
 	var value = textArea.val();
-	value = value.replace(/-/g,''); // strips negative signs
 	value = value.replace(/,,/g,'');
 	value = value.split(",").map(Number);
 	


### PR DESCRIPTION
In getTextAreaData and getDataArray functions I deleted the line "value = value.replace(/-/g,''); // strips negative signs." This allows for negative values to go into the raw data array for pitch mapping and duration mapping per request of client.
